### PR TITLE
added timestamp in dev genesis

### DIFF
--- a/images/algod/dev-genesis.json
+++ b/images/algod/dev-genesis.json
@@ -35,5 +35,6 @@
     "id": "v1",
     "network": "sandnet",
     "proto": "https://github.com/algorandfoundation/specs/tree/d5ac876d7ede07367dbaa26e149aa42589aac1f7",
-    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU"
+    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+    "timestamp": 1560210489
 }


### PR DESCRIPTION
Hi there, I was recently scratching my head trying to figure out why timestamps would "stall" in my local devmode node, leading to all my time-related tests acting very inconsistently. It turned out adding a very early timestamp (matching the one in https://github.com/algorand/sandbox/blob/master/genesis/devnet/genesis.json) fixed it for me. My theory is that this is caused by the genesis timestamp defaulting to system time, and then timestamps of new blocks freeze once caught up (i.e. instantly). Making a PR in case you guys would end up dealing with the same issue.